### PR TITLE
qubes-i3-sensible-terminal: use qrexec-client directly

### DIFF
--- a/qubes-i3-sensible-terminal
+++ b/qubes-i3-sensible-terminal
@@ -21,7 +21,7 @@ get_vm() {
 main() {
     local vm=$(get_vm)
     if [[ -n "$vm" ]]; then
-        qvm-run "$vm" "bash -c '$run_terminal'"
+        qrexec-client -e -d "$vm" DEFAULT:"bash -c '$run_terminal'"
     else # run terminal in dom0
         exec bash -c "$run_terminal"
     fi


### PR DESCRIPTION
Currently qvm-run is used to start a terminal in a vm. However this will
keep stdin/stdout connected depleting inter-VM shared memory which is
a limited resource (as pointed out by Marek Marczykowski-Górecki).

To avoid this use qrexec-client directly with "-e" option to avoid
connecting stdin/stdout.

This should be fine since a running vm is already required to be able to
use qubes-i3-sensible-terminal.

QubesOS/qubes-issues#5969
Signed-off-by: Lukas Czerner <lukas@czerner.cz>