### PR TITLE
Update i3.config to prevent errors for dmenu

### DIFF
--- a/i3.config
+++ b/i3.config
@@ -54,7 +54,7 @@ bindsym Mod1+Shift+q kill
 # There also is the (new) i3-dmenu-desktop which only displays applications
 # shipping a .desktop file. It is a wrapper around dmenu, so you need that
 # installed.
-bindsym Mod1+d exec --no-startup-id i3-dmenu-desktop --dmenu="dmenu -nb #d2d2d2 -nf #333333 -sb #63a0ff -sf #f5f5f5"
+bindsym Mod1+d exec --no-startup-id LANG=C i3-dmenu-desktop --dmenu="dmenu -nb #d2d2d2 -nf #333333 -sb #63a0ff -sf #f5f5f5"
 
 # change focus
 bindsym Mod1+$left focus left


### PR DESCRIPTION
Prevent errors when pressing dmenu-keycombination
(after installing Qubes-OS with non-english locale).

```
warning: no locale support
XOpenIM failed: could not open input device
```