### PR TITLE
fix: remove duplicate `qvm-run "$vm"`

### DIFF
--- a/qubes-i3-sensible-terminal
+++ b/qubes-i3-sensible-terminal
@@ -24,7 +24,7 @@ main() {
         if command -v qrexec-client >/dev/null; then
             qrexec-client -e -d "$vm" DEFAULT:"bash -c '$run_terminal'"
         else
-            qvm-run "$vm" qvm-run "$vm" "bash -c '$run_terminal'"
+            qvm-run "$vm" "bash -c '$run_terminal'"
         fi
     else # run terminal in dom0
         exec bash -c "$run_terminal"


### PR DESCRIPTION
Tested this in dom0, but not with GUI Domain.