### PR TITLE
Include notification daemon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,13 @@
 include:
-- file: /r4.1/gitlab-base.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-dom0.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-vm.yml
-  project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-host.yml
   project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-vm.yml
+  project: QubesOS/qubes-continuous-integration
+- file: /r4.3/gitlab-base.yml
+  project: QubesOS/qubes-continuous-integration
+- file: /r4.3/gitlab-host.yml
+  project: QubesOS/qubes-continuous-integration
+- file: /r4.3/gitlab-vm.yml
   project: QubesOS/qubes-continuous-integration

--- a/i3-settings-qubes.spec.in
+++ b/i3-settings-qubes.spec.in
@@ -18,6 +18,7 @@ Requires:   perl-Data-Dumper
 Requires:   perl-File-Temp 
 Requires:   perl-Getopt-Long 
 Requires:   perl-open
+Recommends: dunst
 
 
 %description


### PR DESCRIPTION
Install a notification daemon (dunst). It includes relevant systemd user
service file, so no i3 configuration change is necessary.

Fixes QubesOS/qubes-issues#8768