### PR TITLE
added sensible browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ install:
 	install -m 644 -D i3.config $(DESTDIR)/etc/i3/config.qubes
 	install -m 644 -D i3.config.keycodes $(DESTDIR)/etc/i3/config.keycodes.qubes
 	install -m 755 -D qubes-i3-sensible-terminal $(DESTDIR)/usr/bin/qubes-i3-sensible-terminal
+	install -m 755 -D qubes-i3-sensible-browser $(DESTDIR)/usr/bin/qubes-i3-sensible-browser
 	install -m 755 -D qubes-i3-xdg-autostart $(DESTDIR)/usr/bin/qubes-i3-xdg-autostart
 	install -m 755 -D qubes-i3status.py $(DESTDIR)/usr/bin/qubes-i3status
 

--- a/debian/install
+++ b/debian/install
@@ -3,3 +3,4 @@ etc/i3/config.keycodes.qubes
 usr/bin/qubes-i3-sensible-terminal
 usr/bin/qubes-i3-xdg-autostart
 usr/bin/qubes-i3status
+usr/bin/qubes-i3-sensible-browser

--- a/i3-settings-qubes.spec.in
+++ b/i3-settings-qubes.spec.in
@@ -62,6 +62,7 @@ fi
 %{_bindir}/qubes-i3-sensible-terminal
 %{_bindir}/qubes-i3-xdg-autostart
 %{_bindir}/qubes-i3status
+%{_bindir}/qubes-i3-sensible-browser
 
 %changelog
 @CHANGELOG@

--- a/i3.config
+++ b/i3.config
@@ -30,7 +30,7 @@ set $audio_mic_mute pactl set-source-mute @DEFAULT_SOURCE@ toggle
 
 set $terminal qubes-i3-sensible-terminal
 set $console qubes-i3-sensible-terminal console
-
+set $browser qubes-i3-sensible-browser
 # start dmenu (a program launcher)
 # j4-dmenu-desktop is not upstreamed but it is much faster.
 set $dmenu_common_args --dmenu="dmenu -l 25 -i -nb \#d2d2d2 -nf \#333333 -sb \#63a0ff -sf \#f5f5f5"
@@ -131,6 +131,12 @@ floating_modifier $mod
 # start a terminal in the domain of the currently active window
 bindsym $mod+Return exec $terminal
 bindsym $mod+Shift+Return exec $console
+
+# start browser inside currently focused qube
+# this tries to open browser inside menu-items in that qube,
+# so make sure you have your prefered browser there,
+# but if you dont it will fallback to trying possible "sensible" browsers which is slower.
+bindsym $mod+Shift+i exec $browser
 
 # kill focused window
 bindsym $mod+Shift+q kill

--- a/qubes-i3-sensible-browser
+++ b/qubes-i3-sensible-browser
@@ -1,0 +1,20 @@
+id="$(xprop -root _NET_ACTIVE_WINDOW)"
+id="${id##* }"
+vm="$(xprop -id "$id" | grep '_QUBES_VMNAME(STRING)' | awk '{print $3}' | tr -d '"')"
+#add more if you feel the need to
+browsers='librewolf|brave-browser|brave-origin-nightly|mullvad-browser|chromium|ungoogled-chromium|waterfox|vivaldi|firefox'
+#this tries to use the browser wants from user's menu items and is fast!
+#each word in $browsers is a different pattern and grep matches them against the menu items
+#also pipes it to head to make sure it doesnt run multiple browsers at the same time or breaks the command if user has more than 1 browser installed
+#if theres a match it will just run the browser using qvm-run
+browser="$(grep -m 1 -owE "$browsers" <(qvm-features $vm menu-items) | head -n1)"
+if [[ -n "$browser" ]]; then
+  echo $browser
+  qvm-run "$vm" "$browser" "$@"
+  exit 0 #success!
+fi
+#fallback to for loop which is slower
+for browser in mullvad-browser librewolf firefox torbrowser-launcher chromium brave-origin brave-browser ungoogled-chromium epiphany falkon waterfox midori qutebrowser vivaldi; do
+  # uses subshell to try to be faster makes a big difference from my tests
+  (qvm-run "$vm" which "$browser" && qvm-run "$vm" "$browser" "$@") &
+done


### PR DESCRIPTION
In my opinion this fits well since we already have qubes-i3-sensible-terminal, qubes-i3-sensible-browser seems like a logical extension to me. this is specially useful when you have different browsers for different templates like I do. let me know if you have any feedback,only thing I'm not sure would be the default keybind for it I set $mod+Shift+i because thats what I have I like it but let me know what you think.