### PR TITLE
Cache Qubes store in i3status

### DIFF
--- a/qubes-i3status.py
+++ b/qubes-i3status.py
@@ -228,41 +228,29 @@ def main():
     print(prefix, flush=True)
 
     loop_count = 0
-    qubesd_status = None
-    qubes_status = None
-    disk_status = None
-    bat_status = None
-    load_status = None
-    volume_status = None
-    net_status = None
+    last_heavy = []
     while True:
         if loop_count % 2 == 0:
+            status_list = []
             try:
-                qubes_status = status_qubes()
-                disk_status = status_disk()
+                status_list.append(status_qubes())
+                status_list.append(status_disk())
                 # network status disabled by default as it's dangerous to run a
                 # command on an untrusted qube from an interface qube.
-                # net_status = status_net()
+                # status_list.append(status_net())
             except qadmin_exc.QubesDaemonCommunicationError:
-                qubesd_status = json_output(
+                status_list.insert(json_output(
                     "qubesd", "qubesd connection failed"
-                )
-            bat_status = status_bat()
-            load_status = status_load()
-            volume_status = status_volume()
+                ), 0)
+            status_list.append(status_bat())
+            status_list.append(status_load())
+            status_list.append(status_volume())
+            last_heavy = status_list.copy()
+        else:
+            status_list = last_heavy
 
-        time_status = status_time()
+        status_list.append(status_time())
 
-        status_list = [
-            qubesd_status,
-            qubes_status,
-            disk_status,
-            bat_status,
-            load_status,
-            volume_status,
-            time_status,
-            net_status,
-        ]
         final_status_list = [
             status for status in status_list if status is not None
         ]

--- a/qubes-i3status.py
+++ b/qubes-i3status.py
@@ -1,13 +1,17 @@
 #!/usr/bin/python3
+
 import re
 import time
 import json
 import subprocess
 import sys
+from asyncio import sleep, create_task, run, gather
 from pathlib import Path
 from datetime import datetime
+
 from qubesadmin import Qubes
 from qubesadmin import exc as qadmin_exc
+from qubesadmin.events import EventsDispatcher
 
 app = Qubes()
 
@@ -65,6 +69,41 @@ def status_net():
                 json_output(net_info["device_name"], net_info["info"])
             )
     return net_status
+
+
+def status_qubes():
+    """
+    Get amount of qubes that are running..
+    """
+    running_qubes = len(
+        [vm for vm in app.domains if vm.klass != "AdminVM" and vm.is_running()]
+    )
+    qube_string = "qube"
+    if running_qubes >= 2:
+        qube_string = "qubes"
+    return json_output("qubes", f"{running_qubes} {qube_string}")
+
+
+def status_disk():
+    """
+    Get amount of space in the default private pool.
+    """
+    default_pool = app.pools[app.property_get_default("default_pool_private")]
+    size = int(default_pool.size)
+    usage = int(default_pool.usage)
+    free = size - usage
+
+    if free >= 1 << 40:
+        disk_free = f"{free >> 40}T"
+    elif free >= 1 << 30:
+        disk_free = f"{free >> 30}G"
+    elif free >= 1 << 20:
+        disk_free = f"{free >> 20}M"
+    elif free >= 1 << 10:
+        disk_free = f"{free >> 10}K"
+    else:
+        disk_free = f"{free} Bytes"
+    return json_output("disk", f"Disk free: {disk_free}")
 
 
 def status_time():
@@ -145,41 +184,6 @@ def status_load():
     return json_output("load", f"Load: {load_avg}")
 
 
-def status_qubes():
-    """
-    Get amount of qubes that are running..
-    """
-    running_qubes = len(
-        [vm for vm in app.domains if vm.klass != "AdminVM" and vm.is_running()]
-    )
-    qube_string = "qube"
-    if running_qubes >= 2:
-        qube_string = "qubes"
-    return json_output("qubes", f"{running_qubes} {qube_string}")
-
-
-def status_disk():
-    """
-    Get amount of space in the default private pool.
-    """
-    default_pool = app.pools[app.property_get_default("default_pool_private")]
-    size = int(default_pool.size)
-    usage = int(default_pool.usage)
-    free = size - usage
-
-    if free >= 1 << 40:
-        disk_free = f"{free >> 40}T"
-    elif free >= 1 << 30:
-        disk_free = f"{free >> 30}G"
-    elif free >= 1 << 20:
-        disk_free = f"{free >> 20}M"
-    elif free >= 1 << 10:
-        disk_free = f"{free >> 10}K"
-    else:
-        disk_free = f"{free} Bytes"
-    return json_output("disk", f"Disk free: {disk_free}")
-
-
 def status_volume():
     """
     Get volume percentage and if muted or not.
@@ -214,9 +218,9 @@ def status_volume():
                 return json_output("volume", f"Volume: {volume}")
 
 
-def main():
+async def painter(app):
     """
-    Query basic statistics to display on i3 status bar.
+    Return JSON for the i3 status bar.
     """
     # Send the header so that i3 bar knows we want to use JSON.
     prefix = '{"version": 1}'
@@ -229,19 +233,24 @@ def main():
 
     loop_count = 0
     last_heavy = []
+    disk_status = []
     while True:
         if loop_count % 2 == 0:
             status_list = []
             try:
                 status_list.append(status_qubes())
-                status_list.append(status_disk())
+                if loop_count % 60 == 0:
+                    # Pool information isn't cached and doesn't change much.
+                    # Call it less frequently.
+                    disk_status = status_disk()
+                status_list.append(disk_status)
                 # network status disabled by default as it's dangerous to run a
                 # command on an untrusted qube from an interface qube.
                 # status_list.append(status_net())
             except qadmin_exc.QubesDaemonCommunicationError:
-                status_list.insert(json_output(
-                    "qubesd", "qubesd connection failed"
-                ), 0)
+                status_list.insert(
+                    json_output("qubesd", "qubesd connection failed"), 0
+                )
             status_list.append(status_bat())
             status_list.append(status_load())
             status_list.append(status_volume())
@@ -256,8 +265,24 @@ def main():
         ]
         print("," + json.dumps(final_status_list), flush=True)
 
-        time.sleep(1)
         loop_count += 1
+        await sleep(1)
+
+
+async def async_main():
+    dispatcher = EventsDispatcher(app)
+    tasks = [
+        create_task(dispatcher.listen_for_events()),
+        create_task(painter(app)),
+    ]
+    await gather(*tasks)
+
+
+def main():
+    """
+    Query basic statistics to display on i3 status bar.
+    """
+    run(async_main())
 
 
 if __name__ == "__main__":

--- a/qubes-i3status.py
+++ b/qubes-i3status.py
@@ -20,50 +20,66 @@ def json_output(name, full_text, color=None):
 
 
 def status_net():
-    netvms = [
-        vm for vm in app.domains if vm.features.get("servicevm") == "1" and not vm.netvm
+    """
+    Query network information such as IP address and the network connected to.
+    """
+    running_netvms = [
+        qube
+        for qube in app.domains
+        if not getattr(qube, "netvm", None)
+        and getattr(qube, "provides_network", False)
+        and qube.is_running()
     ]
     net_status = []
 
-    for netvm in netvms:
-        if not netvm.is_running():
-            continue
-        stdout, _ = netvm.run("ip -o -f inet addr")
-        for line in stdout.decode("utf-8").splitlines():
+    for qube in running_netvms:
+        # TODO: problematic run without timeout.
+        stdout, _ = qube.run("ip -o -f inet addr")
+        for line in stdout.decode("ascii").splitlines():
             match = re.match(
-                r"\d+: ((ens|eth|wl)\S+)(\s+)inet (\d+\.\d+\.\d+\.\d+)\/\d{1,2}", line
+                r"\d+: ((ens|eth|wl)\S+)(\s+)inet (\d+\.\d+\.\d+\.\d+)\/\d{1,2}",
+                line,
             )
-            if match:
-                device_name = match.group(1)
-                ip = match.group(4)
-                net_info = {
-                    "device_name": device_name,
-                    "info": f"{netvm.name}: {ip}",
-                }
-                if device_name.startswith("wl"):
-                    iw_info, _ = netvm.run("iw dev {} link".format(device_name))
-                    ssid = None
-                    for iw_line in iw_info.decode("utf-8").splitlines():
-                        # we allow only word and space characters
-                        ssid_match = re.match(r"^\s+SSID: ([\w\s]*)$", iw_line)
-                        if ssid_match:
-                            ssid = iw_line.split("SSID:")[1].strip()
-                            break
-                    if ssid:
-                        net_info["info"] += f" {ssid}"
+            if not match:
+                continue
+            device_name = match.group(1)
+            ip = match.group(4)
+            net_info = {
+                "device_name": device_name,
+                "info": f"{qube.name}: {ip}",
+            }
+            if device_name.startswith("wl"):
+                # TODO: problematic run without timeout.
+                iw_info, _ = qube.run(f"iw dev {device_name} link")
+                ssid = None
+                for iw_line in iw_info.decode("ascii").splitlines():
+                    # we allow only word and space characters
+                    ssid_match = re.match(r"^\s+SSID: ([\w\s]*)$", iw_line)
+                    if ssid_match:
+                        ssid = iw_line.split("SSID:")[1].strip()
+                        break
+                if ssid:
+                    net_info["info"] += f" {ssid}"
 
-                net_status.append(
-                    json_output(net_info["device_name"], net_info["info"])
-                )
+            net_status.append(
+                json_output(net_info["device_name"], net_info["info"])
+            )
     return net_status
 
 
 def status_time():
+    """
+    Get current time.
+    """
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     return json_output("time", current_time)
 
 
 def status_bat():
+    """
+    Get battery percentage and if charging or not. Color the percentage
+    depending on health.
+    """
     batteries = list(Path("/sys/class/power_supply").glob("BAT*"))
     if not batteries:
         return
@@ -87,7 +103,9 @@ def status_bat():
                     charge_full = battery / "charge_full"
                     if charge_full.exists():
                         charge_full = int(charge_full.read_text().strip())
-                        accum_full_mWh += (voltage_now / 1000) * (charge_full / 1000)
+                        accum_full_mWh += (voltage_now / 1000) * (
+                            charge_full / 1000
+                        )
         except Exception as e:
             print(f"Error reading battery info: {e}", file=sys.stderr)
             return
@@ -119,22 +137,31 @@ def status_bat():
 
 
 def status_load():
+    """
+    Get load average.
+    """
     with open("/proc/loadavg", "r") as f:
         load_avg = f.read().split()[0]
     return json_output("load", f"Load: {load_avg}")
 
 
 def status_qubes():
-    running_qubes = len([vm for vm in app.domains if vm.is_running() and vm.name != "dom0"])
-    if running_qubes == 0:
-        return
-    elif running_qubes == 1:
-        return json_output("qubes", f"{running_qubes} qube")
-    else:
-        return json_output("qubes", f"{running_qubes} qubes")
+    """
+    Get amount of qubes that are running..
+    """
+    running_qubes = len(
+        [vm for vm in app.domains if vm.klass != "AdminVM" and vm.is_running()]
+    )
+    qube_string = "qube"
+    if running_qubes >= 2:
+        qube_string = "qubes"
+    return json_output("qubes", f"{running_qubes} {qube_string}")
 
 
 def status_disk():
+    """
+    Get amount of space in the default private pool.
+    """
     default_pool = app.pools[app.property_get_default("default_pool_private")]
     size = int(default_pool.size)
     usage = int(default_pool.usage)
@@ -154,6 +181,9 @@ def status_disk():
 
 
 def status_volume():
+    """
+    Get volume percentage and if muted or not.
+    """
     try:
         volcmd = subprocess.run(
             ["amixer", "sget", "Master"],
@@ -185,14 +215,19 @@ def status_volume():
 
 
 def main():
+    """
+    Query basic statistics to display on i3 status bar.
+    """
     # Send the header so that i3 bar knows we want to use JSON.
-    print('{"version": 1}', flush=True)
+    prefix = '{"version": 1}'
     # Begin the endless array.
-    print("[", flush=True)
+    prefix += "["
     # We send an empty first array of blocks to make the loop simpler.
-    print("[]", flush=True)
+    prefix += "[]"
 
-    n = 0
+    print(prefix, flush=True)
+
+    loop_count = 0
     qubesd_status = None
     qubes_status = None
     disk_status = None
@@ -201,15 +236,17 @@ def main():
     volume_status = None
     net_status = None
     while True:
-        if n % 2 == 0:
+        if loop_count % 2 == 0:
             try:
                 qubes_status = status_qubes()
                 disk_status = status_disk()
                 # network status disabled by default as it's dangerous to run a
-                # command on an untrusted qube from dom0/adminvm
+                # command on an untrusted qube from an interface qube.
                 # net_status = status_net()
             except qadmin_exc.QubesDaemonCommunicationError:
-                qubesd_status = json_output("qubesd", "qubesd connection failed")
+                qubesd_status = json_output(
+                    "qubesd", "qubesd connection failed"
+                )
             bat_status = status_bat()
             load_status = status_load()
             volume_status = status_volume()
@@ -226,11 +263,13 @@ def main():
             time_status,
             net_status,
         ]
-        final_status_list = [status for status in status_list if status is not None]
+        final_status_list = [
+            status for status in status_list if status is not None
+        ]
         print("," + json.dumps(final_status_list), flush=True)
 
         time.sleep(1)
-        n += 1
+        loop_count += 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There is log spam when enabling `qubesd --log-dom0-call`. It is also slower to query the cache each time. Enable events so the store can be modified and the status can display fresh information without having to make repeated queries to the server.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10963